### PR TITLE
(frontend) fix css bug

### DIFF
--- a/apps/web/src/lib/components/buttons/Submit.svelte
+++ b/apps/web/src/lib/components/buttons/Submit.svelte
@@ -25,8 +25,8 @@
 
 <style lang="postcss">
     button {
-        @apply inline-block rounded-lg bg-[#3580b7];
         @apply px-5 py-3;
+        @apply inline-block rounded-lg bg-[#3580b7];
         @apply text-sm font-bold text-white no-underline;
         @apply shadow-xl shadow-sky-500/20 transition-all duration-300;
     }


### PR DESCRIPTION
<img width="972" alt="image" src="https://user-images.githubusercontent.com/20557318/227376678-82cd7944-37d0-4f24-b198-86af6af7d825.png">

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/20557318/227376692-f5b99bb0-bde6-4e2d-a5e7-c5e3c2d2e5dd.png">

Bug ve Vite / SvelteKit / WindiCSS

Z náhodného důvodu negeneruje css styly 🙈 